### PR TITLE
README.mdのVirtuosoサービスのポート番号を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ VTuber の LOD です (リポジトリ名やORG名は仮のものであり，変
 
 ## develop
 
-http://localhost:8890 に Virtuoso を立ち上げます
+http://localhost:8080 に Virtuoso を立ち上げます
 
 ```bash
 $ docker-compose build
 $ docker-compose up
 ```
 
-http://localhost:8890/sparql/ でクエリを投げたり出来ます
+http://localhost:8080/sparql/ でクエリを投げたり出来ます
 
 例えば，これで VTuber 一覧が取得できます
 


### PR DESCRIPTION
README.mdではVirtuosoのポート番号が`8890`でしたが正しくは`8080`のようです．
README.mdを修正しました．